### PR TITLE
ci: nightly, release pipeline, docker job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,10 @@ jobs:
         run: |
           . .venv/bin/activate
           pytest -q
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build image
+        run: docker build -t tutkija:ci .

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,0 +1,25 @@
+﻿name: E2E Nightly
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install uv
+        run: pipx install uv
+      - name: Setup venv
+        run: |
+          uv venv
+          . .venv/bin/activate
+          uv pip install -e .
+          uv pip install ruff mypy pytest
+      - name: Smoke, la hello
+        run: |
+          . .venv/bin/activate
+          la hello | head -n 3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+﻿name: Release
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Build wheel and sdist
+        run: |
+          python -m pip install build
+          python -m build
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+﻿FROM python:3.11-slim
+
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir .
+
+CMD ["la", "hello"]

--- a/README.md
+++ b/README.md
@@ -15,3 +15,6 @@ Tutkija on projektipohja moniagenttiselle kirjallisuuskatsaukselle. Repossa mÃ�
 - Vaihe 2: laajennettu seulonta, PDF-jÃ¤sentÃ¤minen ja raportointi automatisoituna
 
 Aja `make setup` (tai toteuta vastaavat komennot kÃ¤sin) ennen ensimmÃ¤istÃ¤ muutosta ja varmista pre-commit-koukut komennolla `pre-commit run --all-files`.
+
+## Julkaisu
+Tagaa versio muodossa vX.Y.Z, esimerkki, v0.0.1. CI rakentaa paketit ja tekee GitHub releasen automaattisesti.


### PR DESCRIPTION
## Kuvaus
- lisää nightly e2e savutestin
- lisää tagipohjaisen julkaisupipeline:n
- laajenna CI:tä docker build -jobilla ja dokumentoi julkaisuprosessi READMEen

## Varmistuslista
- [x] testit vihreät paikallisesti
- [x] audit.ps1 palauttaa 0
- [x] ei salaisuuksia kommitoitu
