### PR TITLE
ci: anna release jobille contents write

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
       - 'v*.*.*'
 jobs:
   build-release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Kuvaus
- lisää työkohtaiseen asetukseen contents: write, jotta softprops/action-gh-release toimii

## Varmistuslista
- [x] testit vihreät paikallisesti
- [x] audit.ps1 palauttaa 0
- [x] ei salaisuuksia kommitoitu
