### PR TITLE
chore(ci): enforce PR titles and add templates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+﻿__pycache__/
+.venv/
+.git/
+data/
+cache/
+output/
+dist/
+build/
+*.egg-info/

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+﻿---
+name: Bug Report
+title: "fix: "
+labels: [bug]
+assignees: []
+---
+
+## Kuvaus
+- Mitä tapahtui? Lisää lyhyt kuvaus ja lokit, jos saatavilla.
+
+## Toistaminen
+- [ ] Vaihe 1
+- [ ] Vaihe 2
+- [ ] Vaihe 3
+
+## Odotettu vs. toteutunut
+- Odotettu tulos:
+- Toteutunut tulos:
+
+## Valmiuslista
+- [ ] toistuu tuoreessa mainissa
+- [ ] audit.ps1 palauttaa 0 (tai liitä tulos)
+- [ ] mahdollinen workaround dokumentoitu
+
+## Liitteet
+- Kuvakaappaukset, lokit tai muut artefaktit

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+﻿---
+name: Feature Request
+title: "feat: "
+labels: [enhancement]
+assignees: []
+---
+
+## Tausta
+- Mikä ongelma ratkaistaan?
+- Miten lopputulos arvioidaan?
+
+## Valmiuslista
+- [ ] tavoite kuvattu ja rajattu
+- [ ] hyväksymiskriteerit kirjattu
+- [ ] data/integraatiotarpeet tunnistettu
+
+## Lisätiedot
+- Linkit, referenssit, mockit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,17 @@ jobs:
           uv pip install pytest mypy ruff
           uv pip install -e .
 
+      - name: Check commit message
+        if: github.event_name == 'pull_request'
+        run: |
+          msg="$(jq -r '.pull_request.title' < `$GITHUB_EVENT_PATH)"
+          echo "PR title, $msg"
+          if echo "$msg" | grep -Eiq '^(feat|fix|chore|docs|ci|refactor|test|perf)(\(.+\))?: '; then
+            echo ok
+          else
+            echo "PR otsikon tulee noudattaa muotoa, tyyppi(scope), viesti" && exit 1
+          fi
+
       - name: Lint
         run: |
           . .venv/bin/activate


### PR DESCRIPTION
## Kuvaus
- lisää .dockerignore, nopeuttaa buildia
- tarkistaa PR-otsikon semanttisen muodon CI:ssä
- tuo valmiit issue-template:t bugi- ja feature-työlle

## Varmistuslista
- [x] testit vihreät (CI)
- [x] audit.ps1 palauttaa 0 päähaarassa
- [x] ei salaisuuksia kommitoitu
